### PR TITLE
Test with R 3.1 ... 3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 language: r
 r:
   - 3.1
-  - oldrel
+  - 3.2
+  - 3.3
+  - 3.4
   - release
   - devel
 


### PR DESCRIPTION
PR against master on purpose: You can maintain different versions of `.travis.yml` on both branches, that's the only way I know to have different build matrices on different branches.

When you merge this into `development`, you can revert this one commit c268cb2f in `development` to make sure that `.travis.yml` is different and stays different.