### PR TITLE
Handle systems where char is unsigned.

### DIFF
--- a/src/read.c
+++ b/src/read.c
@@ -613,8 +613,8 @@ struct FANSI_state FANSI_read_next(struct FANSI_state state) {
 
   // Normal ASCII characters
   if(chr_val >= 0x20 && chr_val < 0x7F) state = read_ascii(state);
-  // UTF8 characters (chr_val is signed, so > 0x7f will be negative)
-  else if (chr_val < 0) state = read_utf8(state);
+  // UTF8 characters (if chr_val is signed, then > 0x7f will be negative)
+  else if (chr_val < 0 || chr_val > 0x7f) state = read_utf8(state);
   // ESC sequences
   else if (chr_val == 0x1B) state = read_esc(state);
   // C0 escapes (e.g. \t, \n, etc)

--- a/src/utf8.c
+++ b/src/utf8.c
@@ -27,11 +27,16 @@
  * it.
  */
 
-// check whether any bytes are greater than 127; doesn't really actually confirm
-// this is UTF8
+// Check whether any bytes are greater than 127; doesn't really actually confirm
+// this is UTF8. Note, char may be signed, so > 127 means < 0.
 
 int FANSI_has_utf8(const char * x) {
-  while(*x) {if(*(x++) < 0) return 1;}
+  while(*x) {
+    if(*x < 0 || *x > 127) {
+      return 1;
+    }
+    x++;
+  }
   return 0;
 }
 // nocov start

--- a/src/utils.c
+++ b/src/utils.c
@@ -116,7 +116,7 @@ struct FANSI_csi_pos FANSI_find_esc(const char * x, int what) {
     int found_this = 0;
 
     // If not normal ASCII or UTF8, examine whether we need to found
-    if(!((x_val > 31 && x_val < 127) || x_val < 0)) {
+    if(!((x_val > 31 && x_val < 127) || x_val < 0 || x_val > 127)) {
       if(!found) {
         // Keep resetting strip start point until we find something we want to
         // mark


### PR DESCRIPTION
The code currently assumes that char is signed and that values>127 mean checking for < 0. This is not guaranteed by the spec, and on systems where char is unsigned, these checks fail.

As an example, see [this build](https://koji.fedoraproject.org/koji/taskinfo?taskID=28578188) which fails on aarch64, armv7hl, ppc64(le) and s390x, whereas [this build](https://koji.fedoraproject.org/koji/taskinfo?taskID=28586454) with the attached change is now passing.