### PR TITLE
family->given for R Core authorship

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -7,7 +7,7 @@ Authors@R: c(
     person("Brodie", "Gaslam", email="brodie.gaslam@yahoo.com",
     role=c("aut", "cre")),
     person("Elliott", "Sales De Andrade", role="ctb"),
-    person(family="R Core Team",
+    person(given="R Core Team",
     email="R-core@r-project.org", role="cph",
     comment="UTF8 byte length calcs from src/util.c"
     ))


### PR DESCRIPTION
This is the more typical and correct way to cite this contributor.

c.f.

```r
a = tools::CRAN_authors_db()
sum(grepl("(?i)r core team", a$family))
# [1] 8
sum(grepl("(?i)r core team", a$given))
# [1] 61
```

From `?person`:

> For persons which are not natural persons (e.g., institutions, companies, etc.) it is appropriate to use `given` (but not `family`) for the name, e.g., `person("R Core Team", role = "aut")`.